### PR TITLE
gossamer-adapter: test host-api with wasmtime backend

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -253,7 +253,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [ wasmer ]
+        environment: [ wasmer, wasmtime ]
     name: "[test-host-api] gossamer ${{ matrix.environment }}"
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This enables the host-api fixture for gossamer's wasmtime-based wasm executor as a continuation of w3f/polkadot-spec#408.

This currently still fails with missing import, i.e. `ext_storage_exists_version_1` and therefore depends on ChainSafe/gossamer#1658.