### PR TITLE
host-api: Support test with exported memory

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -139,6 +139,41 @@ jobs:
         name: hostapi-runtime.compact.wasm
         path: bin/hostapi_runtime.compact.wasm
 
+  build-runtime-hostapi-expmem:
+    name: "[build] hostapi-runtime expmem"
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Setup rust toolchain
+      id: rustup
+      uses: actions-rs/toolchain@v1
+      with:
+        target: wasm32-unknown-unknown
+        default: true
+        profile: minimal
+    - name: Cache cargo registry and index
+      uses: actions/cache@v2.1.6
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: cargo-cache-runtime-hostapi-expmem-${{ hashFiles('runtimes/hostapi/Cargo.lock') }}
+        restore-keys: cargo-cache-runtime-hostapi-expmem-
+    - name: Cache cargo build ouput
+      uses: actions/cache@v2.1.6
+      with:
+        path: runtimes/hostapi/target
+        key: cargo-build-runtime-hostapi-expmem-${{ steps.rustup.outputs.rustc_hash }}-${{ hashFiles('runtimes/hostapi/Cargo.lock') }}
+        restore-keys: cargo-build-runtime-hostapi-expmem-${{ steps.rustup.outputs.rustc_hash }}-
+    - name: Build hostapi runtime with exported memory
+      run: make hostapi-runtime-expmem
+    - name: Upload hostapi runtime with exported memory
+      uses: actions/upload-artifact@v2
+      with:
+        name: hostapi-runtime.expmem.compact.wasm
+        path: bin/hostapi_runtime.expmem.compact.wasm
+
 
   test-substrate:
     needs: build-adapter-substrate

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -215,7 +215,7 @@ jobs:
         path: bin
     - run: chmod +x bin/substrate-adapter
     - name: Run test fixture
-      run: ./runtests.jl substrate host-api ${{ matrix.environment }}
+      run: ./runtests.jl substrate host-api --args --environment ${{ matrix.environment }}
 
 
   test-kagome:
@@ -262,7 +262,7 @@ jobs:
         path: bin
     - run: chmod +x bin/kagome-adapter
     - name: Run test fixture
-      run: ./runtests.jl kagome host-api ${{ matrix.environment }}
+      run: ./runtests.jl kagome host-api --args --environment ${{ matrix.environment }}
 
 
   test-gossamer:
@@ -315,4 +315,4 @@ jobs:
         mkdir -p lib
         mv bin/libwasmer.so lib/
     - name: Run test fixture
-      run: ./runtests.jl gossamer host-api ${{ matrix.environment }}
+      run: ./runtests.jl gossamer host-api --args --environment ${{ matrix.environment }}

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -195,13 +195,16 @@ jobs:
       run: ./runtests.jl substrate ${{ matrix.fixture }}
 
   test-substrate-hostapi:
-    needs: [ build-adapter-substrate, build-runtime-hostapi ]
+    needs: [ build-adapter-substrate, build-runtime-hostapi, build-runtime-hostapi-expmem ]
     strategy:
       fail-fast: false
       matrix:
         environment: [ wasmi, wasmtime ]
-    name: "[test-host-api] substrate ${{ matrix.environment }}"
+        runtime: [ default, expmem ]
+    name: "[test-host-api] substrate ${{ matrix.environment }} ${{ matrix.runtime }}"
     runs-on: ubuntu-20.04
+    env:
+      RUNTIME_FILE: hostapi-runtime.${{ matrix.runtime }}.wasm
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -211,11 +214,11 @@ jobs:
         path: bin
     - uses: actions/download-artifact@v2.0.8
       with:
-        name: hostapi-runtime.default.wasm
+        name: ${{ env.RUNTIME_FILE }}
         path: bin
     - run: chmod +x bin/substrate-adapter
     - name: Run test fixture
-      run: ./runtests.jl substrate host-api --args --environment ${{ matrix.environment }}
+      run: ./runtests.jl substrate host-api --args --environment ${{ matrix.environment }} --runtime bin/$RUNTIME_FILE
 
 
   test-kagome:
@@ -242,13 +245,16 @@ jobs:
       run: ./runtests.jl kagome ${{ matrix.fixture }}
 
   test-kagome-hostapi:
-    needs: [ build-adapter-kagome, build-runtime-hostapi ]
+    needs: [ build-adapter-kagome, build-runtime-hostapi, build-runtime-hostapi-expmem ]
     strategy:
       fail-fast: false
       matrix:
         environment: [ binaryen ]
-    name: "[test-host-api] kagome ${{ matrix.environment }}"
+        runtime: [ default, expmem ]
+    name: "[test-host-api] kagome ${{ matrix.environment }} ${{ matrix.runtime }}"
     runs-on: ubuntu-20.04
+    env:
+      RUNTIME_FILE: hostapi-runtime.${{ matrix.runtime }}.wasm
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -258,11 +264,11 @@ jobs:
         path: bin
     - uses: actions/download-artifact@v2.0.8
       with:
-        name: hostapi-runtime.default.wasm
+        name: ${{ env.RUNTIME_FILE }}
         path: bin
     - run: chmod +x bin/kagome-adapter
     - name: Run test fixture
-      run: ./runtests.jl kagome host-api --args --environment ${{ matrix.environment }}
+      run: ./runtests.jl kagome host-api --args --environment ${{ matrix.environment }} --runtime bin/$RUNTIME_FILE
 
 
   test-gossamer:
@@ -292,13 +298,16 @@ jobs:
       run: ./runtests.jl gossamer ${{ matrix.fixture }}
 
   test-gossamer-hostapi:
-    needs: [ build-adapter-gossamer, build-runtime-hostapi]
+    needs: [ build-adapter-gossamer, build-runtime-hostapi, build-runtime-hostapi-expmem ]
     strategy:
       fail-fast: false
       matrix:
         environment: [ wasmer ]
-    name: "[test-host-api] gossamer ${{ matrix.environment }}"
+        runtime: [ default, expmem ]
+    name: "[test-host-api] gossamer ${{ matrix.environment }} ${{ matrix.runtime }}"
     runs-on: ubuntu-20.04
+    env:
+      RUNTIME_FILE: hostapi-runtime.${{ matrix.runtime }}.wasm
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -308,11 +317,11 @@ jobs:
         path: bin
     - uses: actions/download-artifact@v2.0.8
       with:
-        name: hostapi-runtime.default.wasm
+        name: ${{ env.RUNTIME_FILE }}
         path: bin
     - run: |
         chmod +x bin/gossamer-adapter
         mkdir -p lib
         mv bin/libwasmer.so lib/
     - name: Run test fixture
-      run: ./runtests.jl gossamer host-api --args --environment ${{ matrix.environment }}
+      run: ./runtests.jl gossamer host-api --args --environment ${{ matrix.environment }} --runtime bin/$RUNTIME_FILE

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -136,8 +136,8 @@ jobs:
     - name: Upload hostapi runtime
       uses: actions/upload-artifact@v2
       with:
-        name: hostapi-runtime.compact.wasm
-        path: bin/hostapi_runtime.compact.wasm
+        name: hostapi-runtime.default.wasm
+        path: bin/hostapi-runtime.default.wasm
 
   build-runtime-hostapi-expmem:
     name: "[build] hostapi-runtime expmem"
@@ -171,8 +171,8 @@ jobs:
     - name: Upload hostapi runtime with exported memory
       uses: actions/upload-artifact@v2
       with:
-        name: hostapi-runtime.expmem.compact.wasm
-        path: bin/hostapi_runtime.expmem.compact.wasm
+        name: hostapi-runtime.expmem.wasm
+        path: bin/hostapi-runtime.expmem.wasm
 
 
   test-substrate:
@@ -211,7 +211,7 @@ jobs:
         path: bin
     - uses: actions/download-artifact@v2.0.8
       with:
-        name: hostapi-runtime.compact.wasm
+        name: hostapi-runtime.default.wasm
         path: bin
     - run: chmod +x bin/substrate-adapter
     - name: Run test fixture
@@ -258,7 +258,7 @@ jobs:
         path: bin
     - uses: actions/download-artifact@v2.0.8
       with:
-        name: hostapi-runtime.compact.wasm
+        name: hostapi-runtime.default.wasm
         path: bin
     - run: chmod +x bin/kagome-adapter
     - name: Run test fixture
@@ -308,7 +308,7 @@ jobs:
         path: bin
     - uses: actions/download-artifact@v2.0.8
       with:
-        name: hostapi-runtime.compact.wasm
+        name: hostapi-runtime.default.wasm
         path: bin
     - run: |
         chmod +x bin/gossamer-adapter

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ runtimes: $(ALIASES_RUNTIMES)
 $(ALIASES_RUNTIME): %-runtime: init
 	$(MAKE) -C runtimes/$*
 
+hostapi-runtime-expmem: init
+	$(MAKE) -C runtimes/hostapi install-expmem
+
 
 hosts: $(ALIASES_HOST)
 

--- a/adapters/gossamer/host_api/host_api.go
+++ b/adapters/gossamer/host_api/host_api.go
@@ -38,7 +38,7 @@ import (
 import "C"
 
 // Configuration
-const DEFAULT_RUNTIME_PATH = "bin/hostapi_runtime.compact.wasm"
+const DEFAULT_RUNTIME_PATH = "bin/hostapi-runtime.default.wasm"
 
 // String to Integer conversion helper
 func ToUint32(input string) uint32 {

--- a/adapters/kagome/src/host_api/helpers.cpp
+++ b/adapters/kagome/src/host_api/helpers.cpp
@@ -91,7 +91,7 @@ namespace helpers {
   using SubscriptionEngineType = SubscriptionEngine<Buffer, SessionPtr, Buffer, BlockHash>;
 
   // Default runtime location
-  const char* DEFAULT_RUNTIME_PATH = "bin/hostapi_runtime.compact.wasm";
+  const char* DEFAULT_RUNTIME_PATH = "bin/hostapi-runtime.default.wasm";
 
   // Simple wasm provider to provide wasm adapter runtime shim to kagome
   class WasmAdapterProvider : public WasmProvider {

--- a/adapters/substrate/src/host_api/mod.rs
+++ b/adapters/substrate/src/host_api/mod.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use clap::ArgMatches;
 use utils::ParsedInput;
 
-const DEFAULT_RUNTIME_PATH: &str = "bin/hostapi_runtime.compact.wasm";
+const DEFAULT_RUNTIME_PATH: &str = "bin/hostapi-runtime.default.wasm";
 
 pub fn process_host_api_tests(subcmd_matches: &ArgMatches) {
     if let Some(func) = subcmd_matches.value_of("function") {

--- a/helpers/AdapterFixture.jl
+++ b/helpers/AdapterFixture.jl
@@ -117,7 +117,7 @@ function prepare!(self::Builder, implementation="substrate")
 end
 
 "Run all commited test for specified adapter."
-function run(self::Builder, adapter::CmdString, args::CmdString=``)
+function run(self::Builder, adapter::CmdString)
     if length(self.inputs) != length(self.outputs)
         error("Missing or outdated cached reference outputs")
     end
@@ -125,7 +125,8 @@ function run(self::Builder, adapter::CmdString, args::CmdString=``)
     for (input, output) in zip(self.inputs, self.outputs)
 
         # Execute adapter and collect output and exit code
-        cmd = cmdjoin(adapter, cmdjoin(input, args))
+        args = cmdjoin(input, Config.extra_args)
+        cmd = cmdjoin(adapter, args)
 
         if Config.verbose
             println("┌ [COMMAND] ", cmd)
@@ -181,17 +182,7 @@ function execute(self::Builder)
     @testset "$(self.name)" begin
         for implementation in Config.implementations
             adapter = "$implementation-adapter"
-
-
-            if isempty(Config.environments)
-                run(self, adapter)
-            else
-                for environment in Config.environments
-                    @testset "$environment" begin
-                        run(self, adapter, `--environment $environment`)
-                    end
-                end # for environments
-            end
+            run(self, adapter)
         end # for implementations
     end # testset over execute
 end

--- a/helpers/HostFixture.jl
+++ b/helpers/HostFixture.jl
@@ -110,7 +110,7 @@ function run_tester(self::Tester, host::String, duration::Number)
         exec = `docker run -e RUST_LOG=runtime=debug -v $tempdir:$datadir --rm -i $image`
     end
 
-    cmd = `$exec $args`
+    cmd = `$exec $args $(Config.extra_args)`
 
     if Config.verbose
         println("┌ [COMMAND] ", cmd)

--- a/helpers/SpecificationTestsuite.jl
+++ b/helpers/SpecificationTestsuite.jl
@@ -4,7 +4,7 @@ module SpecificationTestsuite
     include("StringHelpers.jl")
 
 
-    export ALL_IMPLEMENTATIONS, ALL_ENVIRONMENTS, ALL_FIXTURES, Config, execute
+    export ALL_IMPLEMENTATIONS, ALL_FIXTURES, Config, execute
 
     "List of all known implementations"
     const ALL_IMPLEMENTATIONS = [
@@ -13,19 +13,9 @@ module SpecificationTestsuite
       "gossamer"
     ]
 
-    "List of all known environments"
-    const ALL_ENVIRONMENTS = [
-        "wasmi"
-        "wasmtime"
-        "wasmer"
-        "life"
-        "binaryen"
-        "wavm"
-    ]
-
     module Config
         import ..SpecificationTestsuite: ALL_IMPLEMENTATIONS
-        import ..StringHelpers: StringList
+        import ..StringHelpers: StringList, CmdString, CmdStringList, cmdjoin
 
         "By default we log on a warning level."
         verbose = false
@@ -43,8 +33,8 @@ module SpecificationTestsuite
         "By default all implementations are enabled."
         implementations = ALL_IMPLEMENTATIONS
 
-        "By default no special environment is selected."
-        environments = []
+        "By default no additional arguments are passed."
+        extra_args = ``
 
         "Path of folder containing all fixtures."
         function fixdir()::String
@@ -74,9 +64,14 @@ module SpecificationTestsuite
             global fixtures = selected
         end
 
-        "Update selected fixtures in config"
-        function set_environments(selected::StringList)
-            global environments = selected
+        "Update additional arguments to pass to executable"
+        function set_extra_args(selected::CmdString)
+            global extra_args = selected
+        end
+
+        "Update additional arguments to pass to executable"
+        function set_extra_args(selected::CmdStringList)
+            set_extra_args(cmdjoin(selected))
         end
 
         "Update docker settings in config"

--- a/runtimes/hostapi/Makefile
+++ b/runtimes/hostapi/Makefile
@@ -1,19 +1,22 @@
 .PHONY: all build install build-expmem install-expmem version clean
 
+RELEASE_WASM_PATH := target/release/wbuild/hostapi-runtime/hostapi_runtime.compact.wasm
+
+
 all: install
 
 build:
 	cargo build --release
 
 install: build
-	cp target/release/wbuild/hostapi-runtime/hostapi_runtime.compact.wasm ../../bin/
+	cp $(RELEASE_WASM_PATH) ../../bin/hostapi-runtime.default.wasm
 
 
 build-expmem:
 	cargo build --features export-memory --release
 
 install-expmem: build-expmem
-	cp target/release/wbuild/hostapi-runtime/hostapi_runtime.compact.wasm ../../bin/hostapi_runtime.expmem.compact.wasm
+	cp $(RELEASE_WASM_PATH) ../../bin/hostapi-runtime.expmem.wasm
 
 
 version:


### PR DESCRIPTION
This PR extends the host-api fixture to support running the hostapi-runtime with exported memory as used in early Kusama.