### PR TITLE
Fix/kagome adapter build 2

### DIFF
--- a/adapters/kagome/.clang-format
+++ b/adapters/kagome/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle: Google
+NamespaceIndentation: All
+BreakBeforeBinaryOperators: NonAssignment
+AlignOperands: true
+DerivePointerAlignment: false
+PointerAlignment: Right
+BinPackArguments: false
+BinPackParameters: false
+AllowShortFunctionsOnASingleLine: Empty
+IncludeBlocks: Preserve

--- a/adapters/kagome/CMakeLists.txt
+++ b/adapters/kagome/CMakeLists.txt
@@ -42,13 +42,12 @@ set(HUNTER_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE})
 # Setup hunter
 include(cmake/HunterGate.cmake)
 HunterGate(
-  URL https://github.com/soramitsu/soramitsu-hunter/archive/v0.23.257-soramitsu13.tar.gz
-  SHA1 072ae2d60b56dd29eab7320da9e090e1b5469cc4
+  URL  https://github.com/soramitsu/soramitsu-hunter/archive/v0.23.257-soramitsu15.tar.gz
+  SHA1  6275b53983398688f467ae6358194ca407b65446
   FILEPATH "${CMAKE_SOURCE_DIR}/cmake/HunterConfig.cmake"
 )
 
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ${HUNTER_ENABLED})
-
 
 # General config
 project(kagome-adapter LANGUAGES CXX C)
@@ -78,7 +77,6 @@ target_link_libraries(kagome-adapter
   Boost::program_options
   yaml-cpp
   ${kagome_LIBRARIES}
-  kagome::binaryen_wasm_memory_factory
 )
 
 

--- a/adapters/kagome/cmake/dependencies.cmake
+++ b/adapters/kagome/cmake/dependencies.cmake
@@ -12,14 +12,6 @@ find_package(kagome REQUIRED CONFIG)
 
 message(STATUS "Found kagome: ${kagome_INCLUDE_DIRS}")
 
-# FIXME Kagome's package config should do all this!
-find_package(Boost REQUIRED COMPONENTS filesystem program_options random)
-find_package(schnorrkel_crust REQUIRED)
-find_package(libsecp256k1 REQUIRED)
-find_package(leveldb REQUIRED)
-find_package(OpenSSL REQUIRED)
-find_package(xxhash REQUIRED)
-find_package(soralog REQUIRED)
-find_package(fmt REQUIRED)
-find_package(libp2p REQUIRED)
-find_package(binaryen REQUIRED)
+include(
+  ${CMAKE_SOURCE_DIR}/../../hosts/kagome/cmake/dependencies.cmake
+  )

--- a/adapters/kagome/src/host_api/crypto.cpp
+++ b/adapters/kagome/src/host_api/crypto.cpp
@@ -63,12 +63,12 @@ namespace crypto {
 
     auto pk1 = environment.execute<typename Suite::PublicKey>(
       "rtm_ext_crypto_"s + Suite::Name + "_generate_version_1",
-      TEST_KEY_TYPE, boost::make_optional(seed1)
+      TEST_KEY_TYPE, std::make_optional(seed1)
     );
 
     auto pk2 = environment.execute<typename Suite::PublicKey>(
       "rtm_ext_crypto_"s + Suite::Name + "_generate_version_1",
-      TEST_KEY_TYPE, boost::make_optional(seed2)
+      TEST_KEY_TYPE, std::make_optional(seed2)
     );
 
     auto keys = environment.execute<std::vector<typename Suite::PublicKey>>(
@@ -96,7 +96,7 @@ namespace crypto {
 
     auto key = environment.execute<typename Suite::PublicKey>(
       "rtm_ext_crypto_"s + Suite::Name + "_generate_version_1",
-      TEST_KEY_TYPE, boost::make_optional(seed));
+      TEST_KEY_TYPE, std::make_optional(seed));
 
     std::cout << key.toHex() << std::endl;
   }
@@ -113,10 +113,10 @@ namespace crypto {
 
     auto pk = environment.execute<typename Suite::PublicKey>(
       "rtm_ext_crypto_"s + Suite::Name + "_generate_version_1",
-      TEST_KEY_TYPE, boost::make_optional(seed)
+      TEST_KEY_TYPE, std::make_optional(seed)
     );
 
-    auto sig = environment.execute<boost::optional<typename Suite::Signature>>(
+    auto sig = environment.execute<std::optional<typename Suite::Signature>>(
       "rtm_ext_crypto_"s + Suite::Name + "_sign_version_1",
       TEST_KEY_TYPE, pk, message
     ).value();
@@ -138,9 +138,9 @@ namespace crypto {
 
     auto pk = environment.execute<typename Suite::PublicKey>(
       "rtm_ext_crypto_"s + Suite::Name + "_generate_version_1",
-      TEST_KEY_TYPE, boost::make_optional(seed)
+      TEST_KEY_TYPE, std::make_optional(seed)
     );
-    auto sig = environment.execute<boost::optional<typename Suite::Signature>>(
+    auto sig = environment.execute<std::optional<typename Suite::Signature>>(
       "rtm_ext_crypto_"s + Suite::Name + "_sign_version_1",
       TEST_KEY_TYPE, pk, message
     ).value();

--- a/adapters/kagome/src/host_api/helpers.cpp
+++ b/adapters/kagome/src/host_api/helpers.cpp
@@ -3,8 +3,8 @@
  *
  * This file is part of Polkadot Host Test Suite
  *
- * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
@@ -21,22 +21,22 @@
 
 #include <fstream>
 
+#include <crypto/bip39/impl/bip39_provider_impl.hpp>
+#include <crypto/crypto_store/crypto_store_impl.hpp>
+#include <crypto/ed25519/ed25519_provider_impl.hpp>
+#include <crypto/hasher/hasher_impl.hpp>
 #include <crypto/pbkdf2/impl/pbkdf2_provider_impl.hpp>
 #include <crypto/random_generator/boost_generator.hpp>
-#include <crypto/ed25519/ed25519_provider_impl.hpp>
-#include <crypto/sr25519/sr25519_provider_impl.hpp>
 #include <crypto/secp256k1/secp256k1_provider_impl.hpp>
-#include <crypto/hasher/hasher_impl.hpp>
-#include <crypto/crypto_store/crypto_store_impl.hpp>
-#include <crypto/bip39/impl/bip39_provider_impl.hpp>
+#include <crypto/sr25519/sr25519_provider_impl.hpp>
 
+#include <storage/changes_trie/impl/storage_changes_tracker_impl.hpp>
 #include <storage/in_memory/in_memory_storage.hpp>
+#include <storage/trie/impl/trie_storage_backend_impl.hpp>
+#include <storage/trie/impl/trie_storage_impl.hpp>
 #include <storage/trie/polkadot_trie/polkadot_trie_factory_impl.hpp>
 #include <storage/trie/serialization/polkadot_codec.hpp>
 #include <storage/trie/serialization/trie_serializer_impl.hpp>
-#include <storage/trie/impl/trie_storage_backend_impl.hpp>
-#include <storage/trie/impl/trie_storage_impl.hpp>
-#include <storage/changes_trie/impl/storage_changes_tracker_impl.hpp>
 #include <storage/trie/types.hpp>
 
 #include <runtime/binaryen/binaryen_memory_factory.hpp>
@@ -63,14 +63,14 @@ namespace helpers {
   using kagome::crypto::Bip39ProviderImpl;
   using kagome::crypto::BoostRandomGenerator;
   using kagome::crypto::CryptoStoreImpl;
-  using kagome::crypto::Ed25519Suite;
-  using kagome::crypto::Sr25519Suite;
   using kagome::crypto::Ed25519ProviderImpl;
-  using kagome::crypto::Sr25519ProviderImpl;
-  using kagome::crypto::KeyFileStorage;
+  using kagome::crypto::Ed25519Suite;
   using kagome::crypto::HasherImpl;
+  using kagome::crypto::KeyFileStorage;
   using kagome::crypto::Pbkdf2ProviderImpl;
   using kagome::crypto::Secp256k1ProviderImpl;
+  using kagome::crypto::Sr25519ProviderImpl;
+  using kagome::crypto::Sr25519Suite;
 
   using kagome::host_api::HostApiFactoryImpl;
 
@@ -81,19 +81,20 @@ namespace helpers {
   using kagome::storage::trie::PolkadotCodec;
   using kagome::storage::trie::PolkadotTrieFactoryImpl;
   using kagome::storage::trie::TrieSerializerImpl;
-  using kagome::storage::trie::TrieStorageImpl;
   using kagome::storage::trie::TrieStorageBackendImpl;
+  using kagome::storage::trie::TrieStorageImpl;
 
   using kagome::subscription::SubscriptionEngine;
 
-  using SubscriptionEngineType = SubscriptionEngine<Buffer, SessionPtr, Buffer, BlockHash>;
+  using SubscriptionEngineType =
+      SubscriptionEngine<Buffer, SessionPtr, Buffer, BlockHash>;
 
   // Default runtime location
-  const char* DEFAULT_RUNTIME_PATH = "bin/hostapi-runtime.default.wasm";
+  const char *DEFAULT_RUNTIME_PATH = "bin/hostapi-runtime.default.wasm";
 
   // Simple wasm provider to provide wasm adapter runtime shim to kagome
-  public:
   class WasmAdapterProvider : public RuntimeCodeProvider {
+   public:
     WasmAdapterProvider(const std::string path) {
       // Open file and determine size (ios::ate jumps to end on open)
       std::ifstream file(path, std::ios::binary | std::ios::ate);
@@ -115,14 +116,16 @@ namespace helpers {
       return code_;
     }
 
-  private:
+   private:
     Buffer code_;
   };
 
   // Default backend to use
-  const RuntimeEnvironment::Backend RuntimeEnvironment::DEFAULT_BACKEND = RuntimeEnvironment::Backend::Binaryen;
+  const RuntimeEnvironment::Backend RuntimeEnvironment::DEFAULT_BACKEND =
+      RuntimeEnvironment::Backend::Binaryen;
 
-  RuntimeEnvironment::RuntimeEnvironment(const std::string path, Backend backend) {
+  RuntimeEnvironment::RuntimeEnvironment(const std::string path,
+                                         Backend backend) {
     // Load wasm adapter shim
     auto wasm_provider = std::make_shared<WasmAdapterProvider>(path);
 
@@ -152,38 +155,40 @@ namespace helpers {
     // Build crypto providers
     auto pbkdf2_provider = std::make_shared<Pbkdf2ProviderImpl>();
     auto random_generator = std::make_shared<BoostRandomGenerator>();
-    auto ed25519_provider = std::make_shared<Ed25519ProviderImpl>(random_generator);
-    auto sr25519_provider = std::make_shared<Sr25519ProviderImpl>(random_generator);
+    auto ed25519_provider =
+        std::make_shared<Ed25519ProviderImpl>(random_generator);
+    auto sr25519_provider =
+        std::make_shared<Sr25519ProviderImpl>(random_generator);
     auto secp256k1_provider = std::make_shared<Secp256k1ProviderImpl>();
     auto hasher = std::make_shared<HasherImpl>();
     auto bip39_provider = std::make_shared<Bip39ProviderImpl>(pbkdf2_provider);
 
-    auto keystore_path = boost::filesystem::temp_directory_path() / "kagome-adapter-host-api";
+    auto keystore_path =
+        boost::filesystem::temp_directory_path() / "kagome-adapter-host-api";
     auto crypto_store = std::make_shared<CryptoStoreImpl>(
-      std::make_shared<Ed25519Suite>(ed25519_provider),
-      std::make_shared<Sr25519Suite>(sr25519_provider),
-      bip39_provider,
-      KeyFileStorage::createAt(keystore_path).value()
-    );
+        std::make_shared<Ed25519Suite>(ed25519_provider),
+        std::make_shared<Sr25519Suite>(sr25519_provider),
+        bip39_provider,
+        KeyFileStorage::createAt(keystore_path).value());
 
     // Assemble host api factory
-    auto hostapi_factory = std::make_shared<HostApiFactoryImpl>(
-      changes_tracker,
-      sr25519_provider,
-      ed25519_provider,
-      secp256k1_provider,
-      hasher,
-      crypto_store,
-      bip39_provider
-    );
+    auto hostapi_factory =
+        std::make_shared<HostApiFactoryImpl>(changes_tracker,
+                                             sr25519_provider,
+                                             ed25519_provider,
+                                             secp256k1_provider,
+                                             hasher,
+                                             crypto_store,
+                                             bip39_provider);
 
     // Waiting for https://github.com/soramitsu/kagome/pull/794
-    BOOST_ASSERT_MSG(backend == Backend::Binaryen, "Only binaryen environment is currently supported");
+    BOOST_ASSERT_MSG(backend == Backend::Binaryen,
+                     "Only binaryen environment is currently supported");
 
     // Build and assmble core factory
     auto header_repo = std::make_shared<KeyValueBlockHeaderRepository>(
-      std::make_shared<InMemoryStorage>(), hasher
-    );
+        std::make_shared<InMemoryStorage>(), hasher);
+
     auto env_factory = std::make_shared<binaryen::InstanceEnvironmentFactory>(
         trie_storage, hostapi_factory, header_repo, changes_tracker);
 
@@ -206,4 +211,4 @@ namespace helpers {
     execute<void>("rtm_ext_storage_set_version_1", ":code", "");
   }
 
-} // namespace helper
+}  // namespace helpers

--- a/adapters/kagome/src/host_api/helpers.cpp
+++ b/adapters/kagome/src/host_api/helpers.cpp
@@ -37,12 +37,16 @@
 #include <storage/trie/impl/trie_storage_backend_impl.hpp>
 #include <storage/trie/impl/trie_storage_impl.hpp>
 #include <storage/changes_trie/impl/storage_changes_tracker_impl.hpp>
+#include <storage/trie/types.hpp>
 
-#include <runtime/common/trie_storage_provider_impl.hpp>
-#include <runtime/binaryen/binaryen_wasm_memory_factory.hpp>
-#include <runtime/binaryen/runtime_environment_factory.hpp>
-#include <runtime/binaryen/module/wasm_module_factory_impl.hpp>
-#include <runtime/binaryen/runtime_api/core_factory_impl.hpp>
+#include <runtime/binaryen/binaryen_memory_factory.hpp>
+#include <runtime/binaryen/instance_environment_factory.hpp>
+#include <runtime/binaryen/module/module_factory_impl.hpp>
+#include <runtime/common/module_repository_impl.hpp>
+#include <runtime/common/runtime_upgrade_tracker_impl.hpp>
+#include <runtime/runtime_api/impl/core.hpp>
+#include <runtime/runtime_code_provider.hpp>
+#include <runtime/runtime_environment_factory.hpp>
 
 #include <host_api/impl/host_api_factory_impl.hpp>
 
@@ -70,13 +74,7 @@ namespace helpers {
 
   using kagome::host_api::HostApiFactoryImpl;
 
-  using kagome::runtime::TrieStorageProviderImpl;
-  using kagome::runtime::WasmProvider;
-
-  using kagome::runtime::binaryen::CoreFactoryImpl;
-  using kagome::runtime::binaryen::RuntimeEnvironmentFactoryImpl;
-  using kagome::runtime::binaryen::WasmModuleFactoryImpl;
-  using kagome::runtime::binaryen::BinaryenWasmMemoryFactory;
+  using kagome::primitives::events::ChainSubscriptionEngine;
 
   using kagome::storage::InMemoryStorage;
   using kagome::storage::changes_trie::StorageChangesTrackerImpl;
@@ -94,8 +92,8 @@ namespace helpers {
   const char* DEFAULT_RUNTIME_PATH = "bin/hostapi-runtime.default.wasm";
 
   // Simple wasm provider to provide wasm adapter runtime shim to kagome
-  class WasmAdapterProvider : public WasmProvider {
   public:
+  class WasmAdapterProvider : public RuntimeCodeProvider {
     WasmAdapterProvider(const std::string path) {
       // Open file and determine size (ios::ate jumps to end on open)
       std::ifstream file(path, std::ios::binary | std::ios::ate);
@@ -110,7 +108,10 @@ namespace helpers {
       file.read(reinterpret_cast<char *>(code_.data()), size);
     }
 
-    const Buffer &getStateCodeAt(const kagome::primitives::BlockHash &at) const override {
+    ~WasmAdapterProvider() override = default;
+
+    outcome::result<gsl::span<const uint8_t>> getCodeAt(
+        const kagome::storage::trie::RootHash &at) const override {
       return code_;
     }
 
@@ -125,30 +126,28 @@ namespace helpers {
     // Load wasm adapter shim
     auto wasm_provider = std::make_shared<WasmAdapterProvider>(path);
 
+    auto storage = std::make_shared<InMemoryStorage>();
+
     // Build storage provider
-    auto storage_backend = std::make_shared<TrieStorageBackendImpl>(
-      std::make_shared<InMemoryStorage>(), Buffer{}
-    );
+    auto storage_backend =
+        std::make_shared<TrieStorageBackendImpl>(storage, Buffer{});
 
     auto trie_factory = std::make_shared<PolkadotTrieFactoryImpl>();
     auto codec = std::make_shared<PolkadotCodec>();
     auto serializer = std::make_shared<TrieSerializerImpl>(
-      trie_factory, codec, storage_backend
-    );
+        trie_factory, codec, storage_backend);
 
-    auto trie_db = TrieStorageImpl::createEmpty(
-      trie_factory, codec, serializer, boost::none
-    ).value();
-
-    auto storage_provider = std::make_shared<TrieStorageProviderImpl>(
-      std::move(trie_db)
-    );
+    std::shared_ptr<kagome::storage::trie::TrieStorageImpl> trie_storage =
+        std::move(TrieStorageImpl::createEmpty(
+                      trie_factory, codec, serializer, std::nullopt)
+                      .value());
 
     // Build change tracker
     auto sub_engine = std::make_shared<SubscriptionEngineType>();
+    auto chain_subscription_engine =
+        std::make_shared<ChainSubscriptionEngine>();
     auto changes_tracker = std::make_shared<StorageChangesTrackerImpl>(
-      trie_factory, codec, sub_engine
-    );
+        trie_factory, codec, sub_engine, chain_subscription_engine);
 
     // Build crypto providers
     auto pbkdf2_provider = std::make_shared<Pbkdf2ProviderImpl>();
@@ -185,25 +184,23 @@ namespace helpers {
     auto header_repo = std::make_shared<KeyValueBlockHeaderRepository>(
       std::make_shared<InMemoryStorage>(), hasher
     );
+    auto env_factory = std::make_shared<binaryen::InstanceEnvironmentFactory>(
+        trie_storage, hostapi_factory, header_repo, changes_tracker);
 
-    auto core_factory = std::make_shared<CoreFactoryImpl>(changes_tracker, header_repo);
+    auto module_factory = std::make_shared<binaryen::ModuleFactoryImpl>(
+        env_factory, trie_storage);
 
-    // Assmble runtime environment factory and runtime api
-    auto memory_factory = std::make_shared<BinaryenWasmMemoryFactory>();
+    std::shared_ptr<RuntimeUpgradeTrackerImpl> runtime_upgrade_tracker =
+        std::move(RuntimeUpgradeTrackerImpl::create(header_repo, storage, {})
+                      .value());
 
-    auto module_factory = std::make_shared<WasmModuleFactoryImpl>();
+    auto module_repo = std::make_shared<ModuleRepositoryImpl>(
+        runtime_upgrade_tracker, module_factory);
 
-    auto environment_factory = std::make_shared<RuntimeEnvironmentFactoryImpl>(
-        core_factory,
-        memory_factory,
-        hostapi_factory,
-        module_factory,
-        wasm_provider,
-        storage_provider,
-        hasher
-    );
+    auto environment_factory = std::make_shared<RuntimeEnvironmentFactory>(
+        wasm_provider, module_repo, header_repo);
 
-    runtime_ = std::make_shared<RawRuntimeApi>(environment_factory);
+    runtime_ = std::make_shared<Executor>(header_repo, environment_factory);
 
     // Set expected defaults in storage
     execute<void>("rtm_ext_storage_set_version_1", ":code", "");

--- a/adapters/kagome/src/host_api/helpers.hpp
+++ b/adapters/kagome/src/host_api/helpers.hpp
@@ -36,7 +36,7 @@ namespace helpers {
   using kagome::common::hex_lower;
 
   using kagome::common::Buffer;
-  using MaybeBuffer = boost::optional<Buffer>;
+  using MaybeBuffer = std::optional<Buffer>;
 
   using kagome::runtime::binaryen::RuntimeApi;
 

--- a/adapters/kagome/src/host_api/helpers.hpp
+++ b/adapters/kagome/src/host_api/helpers.hpp
@@ -3,8 +3,8 @@
  *
  * This file is part of Polkadot Host Test Suite
  *
- * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
@@ -38,45 +38,41 @@ namespace helpers {
   using kagome::common::Buffer;
   using MaybeBuffer = std::optional<Buffer>;
 
-  using kagome::runtime::binaryen::RuntimeApi;
+  using namespace kagome::runtime;
 
   // Default path of runtime
-  extern const char* DEFAULT_RUNTIME_PATH;
+  extern const char *DEFAULT_RUNTIME_PATH;
 
   class RuntimeEnvironment {
-    public:
+   public:
+    // Available backends
+    enum class Backend {
+      Binaryen,
+      WAVM,
+    };
 
-      // Available backends
-      enum class Backend {
-        Binaryen,
-        WAVM,
-      };
+    // Default backend to use
+    static const Backend DEFAULT_BACKEND;
 
-      // Default backend to use
-      static const Backend DEFAULT_BACKEND;
+    // Initialize a runtime environment
+    RuntimeEnvironment(const std::string path = DEFAULT_RUNTIME_PATH,
+                       Backend backend = DEFAULT_BACKEND);
 
-      // Initialize a runtime environment
-      RuntimeEnvironment(
-        const std::string path = DEFAULT_RUNTIME_PATH,
-        Backend backend = DEFAULT_BACKEND
-      );
-
-      // Call function with provided arguments in wasm adapter
-      template <typename R, typename... Args>
-      R execute(std::string_view name, Args &&... args) {
-
-        BOOST_ASSERT_MSG(result, result.error().message().data());
-
+    // Call function with provided arguments in wasm adapter
+    template <typename R, typename... Args>
+    R execute(std::string_view name, Args &&...args) {
       auto result = runtime_->persistentCallAtGenesis<R>(
           name, std::forward<Args>(args)...);
-      }
 
-    private:
+      BOOST_ASSERT_MSG(result, result.error().message().data());
+
       if constexpr (not std::is_same_v<R, void>) {
         return result.value().result;
       }
+    }
 
-      // Main object used to execute calls
+   private:
+    // Main object used to execute calls
     std::shared_ptr<Executor> runtime_;
   };
-}
+}  // namespace helpers

--- a/adapters/kagome/src/state_trie.cpp
+++ b/adapters/kagome/src/state_trie.cpp
@@ -3,8 +3,8 @@
  *
  * This file is part of Polkadot Host Test Suite
  *
- * Polkadot Host Test Suite is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * Polkadot Host Test Suite is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
@@ -21,21 +21,21 @@
 
 #include "assert.hpp"
 
+#include <boost/optional.hpp>
 #include <boost/program_options.hpp>
 
 #include <yaml-cpp/yaml.h>
 
 #include <storage/in_memory/in_memory_storage.hpp>
+#include <storage/trie/impl/trie_storage_backend_impl.hpp>
+#include <storage/trie/impl/trie_storage_impl.hpp>
 #include <storage/trie/polkadot_trie/polkadot_trie_factory_impl.hpp>
 #include <storage/trie/serialization/polkadot_codec.hpp>
 #include <storage/trie/serialization/trie_serializer_impl.hpp>
-#include <storage/trie/impl/trie_storage_backend_impl.hpp>
-#include <storage/trie/impl/trie_storage_impl.hpp>
 
 #include "subcommand.hpp"
 
 #include <iostream>
-
 
 namespace po = boost::program_options;
 
@@ -48,8 +48,8 @@ using kagome::storage::trie::PolkadotCodec;
 using kagome::storage::trie::PolkadotTrieFactoryImpl;
 using kagome::storage::trie::PolkadotTrieImpl;
 using kagome::storage::trie::TrieSerializerImpl;
-using kagome::storage::trie::TrieStorageImpl;
 using kagome::storage::trie::TrieStorageBackendImpl;
+using kagome::storage::trie::TrieStorageImpl;
 
 TrieCommandArgs extractTrieArgs(int argc, char **argv) {
   po::options_description desc("Trie codec related tests\nAllowed options:");
@@ -99,8 +99,8 @@ TrieCommandArgs extractTrieArgs(int argc, char **argv) {
                          .state_file_name = *state_file_name};
 }
 
-std::pair<std::vector<Buffer>, std::vector<Buffer>>
-parseYamlStateFile(const std::string &filename, bool keys_in_hex, bool values_in_hex) {
+std::pair<std::vector<Buffer>, std::vector<Buffer>> parseYamlStateFile(
+    const std::string &filename, bool keys_in_hex, bool values_in_hex) {
   YAML::Node state = YAML::LoadFile(filename);
   std::vector<Buffer> keys;
   keys.reserve(state["keys"].size());
@@ -113,8 +113,8 @@ parseYamlStateFile(const std::string &filename, bool keys_in_hex, bool values_in
       BOOST_ASSERT_MSG(res, "Invalid hex key");
       b_key = Buffer{res.value()};
     } else {
-      std::copy(key_str.begin(), key_str.end(),
-                std::back_inserter(b_key.asVector()));
+      std::copy(
+          key_str.begin(), key_str.end(), std::back_inserter(b_key.asVector()));
     }
     keys.push_back(b_key);
   }
@@ -129,8 +129,8 @@ parseYamlStateFile(const std::string &filename, bool keys_in_hex, bool values_in
       BOOST_ASSERT_MSG(res, "Invalid hex value");
       b_val = Buffer{res.value()};
     } else {
-    std::copy(val_str.begin(), val_str.end(),
-              std::back_inserter(b_val.asVector()));
+      std::copy(
+          val_str.begin(), val_str.end(), std::back_inserter(b_val.asVector()));
     }
     values.push_back(b_val);
   }
@@ -142,57 +142,61 @@ parseYamlStateFile(const std::string &filename, bool keys_in_hex, bool values_in
 void processTrieCommand(const TrieCommandArgs &args) {
   // Initialize empty trie
   auto backend = std::make_shared<TrieStorageBackendImpl>(
-    std::make_shared<InMemoryStorage>(),
-    kagome::common::Buffer{}
-  );
+      std::make_shared<InMemoryStorage>(), kagome::common::Buffer{});
 
   auto trie_factory = std::make_shared<PolkadotTrieFactoryImpl>();
-  auto codec        = std::make_shared<PolkadotCodec>();
-  auto serializer   = std::make_shared<TrieSerializerImpl>(
-    trie_factory, codec, backend
-  );
+  auto codec = std::make_shared<PolkadotCodec>();
+  auto serializer =
+      std::make_shared<TrieSerializerImpl>(trie_factory, codec, backend);
 
   auto trie_db = TrieStorageImpl::createEmpty(
-    trie_factory, codec, serializer, boost::none
-  ).value();
+                     trie_factory, codec, serializer, std::nullopt)
+                     .value();
 
   auto trie = trie_db->getPersistentBatch().value();
 
   // Execute requested command
   SubcommandRouter<std::vector<Buffer>, std::vector<Buffer>> router;
-  router.addSubcommand("insert-and-delete", [&trie, &args](
-                                                std::vector<Buffer> keys,
-                                                std::vector<Buffer> values) {
-    for (auto keys_it = keys.begin(), values_it = values.begin();
-         keys_it != keys.end(); keys_it++, values_it++) {
-      auto res = trie->put(*keys_it, *values_it);
-      BOOST_ASSERT_MSG(res, "Error inserting to Trie");
-      std::cout << "state root: " << hex_lower(trie->commit().value()) << "\n";
-    }
-    // drop random nodes
-    while (not keys.empty()) {
-      auto key_index_to_drop = trie->commit().value()[0] % keys.size();
-      auto key_to_drop = keys.begin();
-      std::advance(key_to_drop, key_index_to_drop);
-      BOOST_ASSERT_MSG(trie->remove(*key_to_drop), "Error removing from Trie");
-      std::cout << "state root: " << hex_lower(trie->commit().value()) << "\n";
-      keys.erase(key_to_drop);
-    }
-  });
-  router.addSubcommand("trie-root", [&trie, &args](std::vector<Buffer> keys,
-                                                   std::vector<Buffer> values) {
-    for (auto keys_it = keys.begin(), values_it = values.begin();
-         keys_it != keys.end(); keys_it++, values_it++) {
-      BOOST_ASSERT_MSG(trie->put(*keys_it, *values_it),
-                       "Error inserting to Trie");
-    }
-    std::cout << "state root: " << hex_lower(trie->commit().value()) << "\n";
-  });
+  router.addSubcommand(
+      "insert-and-delete",
+      [&trie, &args](std::vector<Buffer> keys, std::vector<Buffer> values) {
+        for (auto keys_it = keys.begin(), values_it = values.begin();
+             keys_it != keys.end();
+             keys_it++, values_it++) {
+          auto res = trie->put(*keys_it, *values_it);
+          BOOST_ASSERT_MSG(res, "Error inserting to Trie");
+          std::cout << "state root: " << hex_lower(trie->commit().value())
+                    << "\n";
+        }
+        // drop random nodes
+        while (not keys.empty()) {
+          auto key_index_to_drop = trie->commit().value()[0] % keys.size();
+          auto key_to_drop = keys.begin();
+          std::advance(key_to_drop, key_index_to_drop);
+          BOOST_ASSERT_MSG(trie->remove(*key_to_drop),
+                           "Error removing from Trie");
+          std::cout << "state root: " << hex_lower(trie->commit().value())
+                    << "\n";
+          keys.erase(key_to_drop);
+        }
+      });
+  router.addSubcommand(
+      "trie-root",
+      [&trie, &args](std::vector<Buffer> keys, std::vector<Buffer> values) {
+        for (auto keys_it = keys.begin(), values_it = values.begin();
+             keys_it != keys.end();
+             keys_it++, values_it++) {
+          BOOST_ASSERT_MSG(trie->put(*keys_it, *values_it),
+                           "Error inserting to Trie");
+        }
+        std::cout << "state root: " << hex_lower(trie->commit().value())
+                  << "\n";
+      });
 
-  auto [keys, values] =
-    parseYamlStateFile(args.state_file_name, args.keys_in_hex, args.values_in_hex);
+  auto [keys, values] = parseYamlStateFile(
+      args.state_file_name, args.keys_in_hex, args.values_in_hex);
 
-  BOOST_VERIFY_MSG(router.executeSubcommand(args.subcommand, std::move(keys),
-                                            std::move(values)),
+  BOOST_VERIFY_MSG(router.executeSubcommand(
+                       args.subcommand, std::move(keys), std::move(values)),
                    "Invalid subcommand");
 }


### PR DESCRIPTION
1. Bump soramitsu-hunter version.
2. Fix build on boost::optional -> std::optional refactoring at kagome.
3. Fix kagome-adapter host-api test build after host architecture update at kagome.
4. Add clang-format script, format kagome-adapter