### PR TITLE
ci: enable kagome host-api test with wavm

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -249,7 +249,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [ binaryen ]
+        environment: [ binaryen, wavm ]
         runtime: [ default, expmem ]
     name: "[test-host-api] kagome ${{ matrix.environment }} ${{ matrix.runtime }}"
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This runs the host-api fixture also for the wavm backend of kagome.