### PR TITLE
 ci: Update caching path and methods

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -6,7 +6,7 @@ on:
     - main
   pull_request:
     paths:
-    - '.github/workflows/testsuite.yml'
+    - '.github/workflows/conformance.yml'
     - '**'
     - '!fixtures/genesis/**'
     - '!helpers/ImplementationFixture.jl'
@@ -33,8 +33,9 @@ jobs:
       uses: actions/cache@v2.1.6
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
         key: cargo-cache-adapter-substrate-${{ hashFiles('adapters/substrate/Cargo.lock') }}
         restore-keys: cargo-cache-adapter-substrate-
     - name: Cache cargo build ouput
@@ -91,7 +92,9 @@ jobs:
     - name: Cache go modules
       uses: actions/cache@v2.1.6
       with:
-        path: ~/go/pkg/mod
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
         key: go-mod-adapter-gossamer-${{ hashFiles('adapters/gossamer/go.sum') }}
         restore-keys: go-mod-adapter-gossamer-
     - name: Build gossamer adapter
@@ -125,8 +128,9 @@ jobs:
       uses: actions/cache@v2.1.6
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
         key: cargo-cache-runtime-hostapi-${{ hashFiles('runtimes/hostapi/Cargo.lock') }}
         restore-keys: cargo-cache-runtime-hostapi-
     - name: Cache cargo build ouput
@@ -160,8 +164,9 @@ jobs:
       uses: actions/cache@v2.1.6
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
         key: cargo-cache-runtime-hostapi-expmem-${{ hashFiles('runtimes/hostapi/Cargo.lock') }}
         restore-keys: cargo-cache-runtime-hostapi-expmem-
     - name: Cache cargo build ouput

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -60,17 +60,15 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Cache hunter packages
-      uses: actions/cache@v2.1.6
-      with:
-        path: ~/.hunter
-        key: hunter-adapter-kagome-${{ hashFiles('adapters/kagome/CMakeLists.txt') }}
-        restore-keys: hunter-adapter-kagome-
-    - name: Build kagome adapter
+    - name: Install gitpython
+      run: sudo apt-get install -y python3-git
+    - name: Build kagome adapter (with caching)
       env:
         CC: gcc-9
         CXX: g++-9
-      run: make kagome-adapter 
+        HUNTER_UPLOAD_USERNAME: ${{ secrets.HUNTER_UPLOAD_USER }}
+        HUNTER_UPLOAD_PASSWORD: ${{ secrets.HUNTER_UPLOAD_TOKEN }}
+      run: make kagome-adapter
     - name: Upload kagome adapter
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,8 +36,9 @@ jobs:
       uses: actions/cache@v2.1.6
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
         key: cargo-cache-host-substrate-${{ hashFiles('hosts/substrate/Cargo.lock') }}
         restore-keys: cargo-cache-host-substrate-
     - name: Cache cargo build output
@@ -95,7 +96,9 @@ jobs:
     - name: Cache go modules
       uses: actions/cache@v2.1.6
       with:
-        path: ~/go/pkg/mod
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
         key: go-mod-host-gossamer-${{ hashFiles('hosts/gossamer/go.sum') }}
         restore-keys: go-mod-host-gossamer-
     - name: Build gossamer
@@ -129,8 +132,9 @@ jobs:
       uses: actions/cache@v2.1.6
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
         key: cargo-cache-adapter-substrate-${{ hashFiles('adapters/substrate/Cargo.lock') }}
         restore-keys: cargo-cache-adapter-substrate-
     - name: Cache cargo build ouput
@@ -171,8 +175,9 @@ jobs:
       uses: actions/cache@v2.1.6
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
         key: cargo-cache-runtime-tester-${{ hashFiles('runtimes/tester/Cargo.lock') }}
         restore-keys: cargo-cache-runtime-tester-
     - name: Cache cargo build output

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ jobs:
         path: hosts/substrate/target
         key: cargo-build-host-substrate-${{ steps.rustup.outputs.rustc_hash }}-${{ hashFiles('hosts/substrate/Cargo.lock') }}
         restore-keys: cargo-build-host-substrate-${{ steps.rustup.outputs.rustc_hash }}-
-    - name: Build substrate
+    - name: Build substrate host
       run: make substrate-host
     - name: Upload substrate
       uses: actions/upload-artifact@v2
@@ -63,23 +63,22 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Cache hunter outputs
-      uses: actions/cache@v2.1.6
-      with:
-        path: ~/.hunter
-        key: hunter-host-kagome-${{ hashFiles('hosts/kagome/CMakeLists.txt') }}
-        restore-keys: hunter-host-kagome-
-    - name: Build kagome
+    - name: Install gitpython
+      run: sudo apt-get install -y python3-git
+    - name: Build kagome host (with caching)
       env:
         CC: gcc-9
         CXX: g++-9
+        HUNTER_UPLOAD_USERNAME: ${{ secrets.HUNTER_UPLOAD_USER }}
+        HUNTER_UPLOAD_PASSWORD: ${{ secrets.HUNTER_UPLOAD_TOKEN }}
+        GITHUB_HUNTER_USERNAME: DUMMY_USER
+        GITHUB_HUNTER_TOKEN: DUMMY_TOKEN
       run: make kagome-host
     - name: Upload kagome hosts
       uses: actions/upload-artifact@v2
       with:
         name: kagome-host
-        path: |
-          bin/kagome
+        path: bin/kagome
 
   build-host-gossamer:
     name: "[build] gossamer-host"
@@ -101,7 +100,7 @@ jobs:
           ~/go/pkg/mod
         key: go-mod-host-gossamer-${{ hashFiles('hosts/gossamer/go.sum') }}
         restore-keys: go-mod-host-gossamer-
-    - name: Build gossamer
+    - name: Build gossamer host
       run: make gossamer-host
     - name: Upload gossamer and libwasmer
       uses: actions/upload-artifact@v2

--- a/adapters/kagome/CMakeLists.txt
+++ b/adapters/kagome/CMakeLists.txt
@@ -25,20 +25,38 @@ set(CMAKE_TOOLCHAIN_FILE
   CACHE FILEPATH "Default toolchain"
 )
 
-
-# Setup but disable binary cache by default
-set(
-  HUNTER_USE_CACHE_SERVERS "NO"
-  CACHE STRING "Binary cache server"
-)
-
-set(
-  HUNTER_CACHE_SERVERS "https://github.com/soramitsu/hunter-binary-cache;"
-  CACHE STRING "Binary cache server"
-)
-
 # Propagate CMake build type to dependencies
-set(HUNTER_CONFIGURATION_TYPES ${CMAKE_BUILD_TYPE})
+set(
+  HUNTER_CONFIGURATION_TYPES "${CMAKE_BUILD_TYPE}"
+  CACHE STRING "Hunter configuration type"
+)
+
+# Enable upload to binary cache if username and password are supplied
+if(DEFINED ENV{HUNTER_UPLOAD_USERNAME} AND DEFINED ENV{HUNTER_UPLOAD_PASSWORD})
+  set(HUNTER_RUN_UPLOAD YES CACHE BOOL "Upload to binary cache")
+else()
+  set(HUNTER_RUN_UPLOAD NO CACHE BOOL "Upload to binary cache")
+endif ()
+
+set(
+  HUNTER_PASSWORDS_PATH "${CMAKE_SOURCE_DIR}/cmake/HunterPasswords.cmake"
+  CACHE FILEPATH "Hunter passwords files"
+)
+
+message(STATUS "Upload to binary cache: ${HUNTER_RUN_UPLOAD}")
+
+# Setup binary cache and enable if upload is enabled
+set(
+  HUNTER_USE_CACHE_SERVERS ${HUNTER_RUN_UPLOAD}
+  CACHE STRING "Binary cache server"
+)
+
+set(
+  HUNTER_CACHE_SERVERS "https://github.com/w3f/hunter-binary-cache"
+  CACHE STRING "Binary cache server"
+)
+
+message(STATUS "Download from binary cache: ${HUNTER_USE_CACHE_SERVERS}")
 
 # Setup hunter
 include(cmake/HunterGate.cmake)

--- a/adapters/kagome/Makefile
+++ b/adapters/kagome/Makefile
@@ -1,31 +1,46 @@
-.PHONY: all build enable-bincache disable-bincache enable-hunter disable-hunter install version clean
+.PHONY: all configure build install enable-hunter disable-hunter enable-bincache disable-bincache enable-upload disable-upload version format clean
 
 all: install
 
-build:
+
+configure: 
 	cmake -DCMAKE_BUILD_TYPE=Release -S . -B build
+
+build: configure
 	cmake --build build
 
-enable-bincache:
+install: build
+	cp build/kagome-adapter ../../bin/
+
+
+enable-hunter: 
+	cmake -DHUNTER_ENABLED=YES -S . -B build
+
+disable-hunter: 
+	cmake -DHUNTER_ENABLED=NO -S . -B build
+
+
+enable-bincache: 
 	cmake -DHUNTER_USE_CACHE_SERVERS=YES -S . -B build
 
 disable-bincache:
 	cmake -DHUNTER_USE_CACHE_SERVERS=NO -S . -B build
 
-enable-hunter:
-	cmake -DHUNTER_ENABLED=true -S . -B build
 
-disable-hunter:
-	cmake -DHUNTER_ENABLED=false -S . -B build
+enable-upload:
+	cmake -DHUNTER_RUN_UPLOAD=YES -S . -B build
 
-install: build
-	cp build/kagome-adapter ../../bin/
+disable-upload:
+	cmake -DHUNTER_RUN_UPLOAD=NO -S . -B build
+
 
 version:
 	@grep "github.com/soramitsu/kagome" cmake/HunterConfig.cmake | grep -o -E "[0-9a-f]{40}"
 
+
 format:
 	find src -iname *.hpp -o -iname *.cpp | xargs clang-format -i
+
 
 clean:
 	rm -rf build

--- a/adapters/kagome/cmake/HunterPasswords.cmake
+++ b/adapters/kagome/cmake/HunterPasswords.cmake
@@ -1,0 +1,7 @@
+
+hunter_upload_password(
+  REPO_OWNER "w3f"
+  REPO "hunter-binary-cache"
+  USERNAME "$ENV{HUNTER_UPLOAD_USERNAME}"
+  PASSWORD "$ENV{HUNTER_UPLOAD_PASSWORD}"
+)

--- a/hosts/Makefile
+++ b/hosts/Makefile
@@ -9,7 +9,7 @@ substrate:
 	cp substrate/target/release/polkadot ../bin/
 
 kagome:
-	cmake -DCMAKE_BUILD_TYPE=Release -DHUNTER_CONFIGURATION_TYPES=Release -S kagome -B kagome/build
+	cmake -DCMAKE_BUILD_TYPE=Release -DHUNTER_CONFIGURATION_TYPES=Release -DHUNTER_PASSWORDS_PATH="$(CURDIR)/../adapters/kagome/cmake/HunterPasswords.cmake" -DHUNTER_CACHE_SERVERS="https://github.com/w3f/hunter-binary-cache" -S kagome -B kagome/build
 	cmake --build kagome/build
 	cp kagome/build/node/kagome ../bin/
 


### PR DESCRIPTION
This updates the Rust and Go caching paths and replaces the hunter cache with the builtin one.

This should fix CI buils times.