### PR TITLE
substrate-host: skip wasm build

### DIFF
--- a/hosts/Makefile
+++ b/hosts/Makefile
@@ -5,7 +5,7 @@ all: substrate kagome gossamer
 
 
 substrate:
-	cd substrate && cargo build --release
+	cd substrate && SKIP_WASM_BUILD=1 cargo build --release
 	cp substrate/target/release/polkadot ../bin/
 
 kagome:


### PR DESCRIPTION
As we currently do not use the wasm binaries build with the substrate host, we might as well skip building them. This should speed up CI runtime as well.