### PR TITLE
tester-runtime: drop substrate-adapter and yq as a dependency

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -8,8 +8,8 @@ on:
     paths:
     - '.github/workflows/conformance.yml'
     - '**'
-    - '!fixtures/genesis/**'
-    - '!helpers/ImplementationFixture.jl'
+    - '!fixtures/genesis-raw/**'
+    - '!helpers/HostFixture.jl'
     - '!runtimes/tester/**'
     - '!hosts/Makefile'
     - '!hosts/substrate'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,9 +9,9 @@ on:
     - '.github/workflows/integration.yml'
     - '**'
     - '!adapters/**'
-    - 'adapters/substrate/**'
     - '!fixtures/**'
     - 'fixtures/genesis/**'
+    - 'fixtures/genesis-raw/**'
     - '!helpers/AdapterFixture.jl'
     - '!runtimes/hostapi/**'
     - '!README.md'
@@ -122,43 +122,6 @@ jobs:
         path: lib/libwasmer.so
 
 
-  build-adapter-substrate:
-    name: "[build] substrate-adapter"
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-    - name: Setup rust toolchain
-      id: rustup
-      uses: actions-rs/toolchain@v1
-      with:
-        target: wasm32-unknown-unknown
-        default: true
-        profile: minimal
-    - name: Cache cargo registry and index
-      uses: actions/cache@v2.1.7
-      with:
-        path: |
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-        key: cargo-cache-adapter-substrate-${{ hashFiles('adapters/substrate/Cargo.lock') }}
-        restore-keys: cargo-cache-adapter-substrate-
-    - name: Cache cargo build ouput
-      uses: actions/cache@v2.1.7
-      with:
-        path: adapters/substrate/target
-        key: cargo-build-adapter-substrate-${{ steps.rustup.outputs.rustc_hash }}-${{ hashFiles('adapters/substrate/Cargo.lock') }}
-        restore-keys: cargo-build-adapter-substrate-${{ steps.rustup.outputs.rustc_hash }}-
-    - name: Build substrate adapters
-      run: make substrate-adapter
-    - name: Upload substrate adapter
-      uses: actions/upload-artifact@v2
-      with:
-        name: substrate-adapter
-        path: bin/substrate-adapter
-
-
   build-runtime-tester:
     name: "[build] tester-runtime"
     runs-on: ubuntu-20.04
@@ -172,12 +135,6 @@ jobs:
         target: wasm32-unknown-unknown
         default: true
         profile: minimal
-    - name: Setup python toolchain
-      uses: actions/setup-python@v2
-    - name: Install yq
-      run: |
-        python -m pip install wheel
-        python -m pip install yq
     - name: Cache cargo registry and index
       uses: actions/cache@v2.1.7
       with:
@@ -200,18 +157,18 @@ jobs:
       with:
         name: tester_runtime.compact.wasm
         path: runtimes/tester/target/release/wbuild/tester-runtime/tester_runtime.compact.wasm
-    - name: Upload host tester genesis and state file
+    - name: Upload host tester genesis and hash file
       uses: actions/upload-artifact@v2
       with:
         name: tester-runtime-genesis
         path: |
-          runtimes/tester/genesis.json
-          runtimes/tester/genesis.yaml
+          runtimes/tester/genesis.hash
+          runtimes/tester/genesis.raw.json
 
 
   test-substrate:
-    needs: [ build-host-substrate, build-adapter-substrate, build-runtime-tester ]
-    name: "[test-genesis] substrate"
+    needs: [ build-host-substrate, build-runtime-tester ]
+    name: "[test-genesis-raw] substrate"
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
@@ -223,19 +180,14 @@ jobs:
     - run: chmod +x bin/polkadot
     - uses: actions/download-artifact@v2.1.0
       with:
-        name: substrate-adapter
-        path: bin
-    - run: chmod +x bin/substrate-adapter
-    - uses: actions/download-artifact@v2.1.0
-      with:
         name: tester-runtime-genesis
         path: runtimes/tester
     - name: Run substrate with tester genesis
-      run: ./runtests.jl substrate genesis
+      run: ./runtests.jl substrate genesis-raw
 
   test-kagome:
-    needs: [ build-host-kagome, build-adapter-substrate, build-runtime-tester ]
-    name: "[test-genesis] kagome"
+    needs: [ build-host-kagome, build-runtime-tester ]
+    name: "[test-genesis-raw] kagome"
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
@@ -247,19 +199,14 @@ jobs:
     - run: chmod +x bin/kagome
     - uses: actions/download-artifact@v2.1.0
       with:
-        name: substrate-adapter
-        path: bin
-    - run: chmod +x bin/substrate-adapter
-    - uses: actions/download-artifact@v2.1.0
-      with:
         name: tester-runtime-genesis
         path: runtimes/tester
     - name: Run kagome with tester genesis
-      run: ./runtests.jl kagome genesis
+      run: ./runtests.jl kagome genesis-raw
 
   test-gossamer:
-    needs: [ build-host-gossamer, build-adapter-substrate, build-runtime-tester ]
-    name: "[test-genesis] gossamer"
+    needs: [ build-host-gossamer, build-runtime-tester ]
+    name: "[test-genesis-raw] gossamer"
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout repository
@@ -274,12 +221,7 @@ jobs:
         mv bin/libwasmer.so lib/
     - uses: actions/download-artifact@v2.1.0
       with:
-        name: substrate-adapter
-        path: bin
-    - run: chmod +x bin/substrate-adapter
-    - uses: actions/download-artifact@v2.1.0
-      with:
         name: tester-runtime-genesis
         path: runtimes/tester
     - name: Run gossamer with tester genesis
-      run: ./runtests.jl gossamer genesis
+      run: ./runtests.jl gossamer genesis-raw

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ To build and run the test suite from source, it depends on the following compone
 - _rust-nightly_ (with wasm target) to build substrate host and adpater (as well as testers and wasm-adapter)
 - _cmake_ and _gcc_ or _clang_ (version 8 or 9 of either) to build kagome host and adapter
 - _go_ to build gossamer host and adapter
-- _jq_ and _yq_ to convert the host-tester genesis
 
 While the official target of our testsuite are currently only debian-based systems, there is in general no reason for it to not be able to run on any recent GNU/Linux or even UNIX-based OS, like OS X.
 
@@ -90,12 +89,8 @@ apt update && apt install -y --no-install-recommends \
   gcc-8 \
   g++-8 \
   golang \
-  julia \
-  python \
-  jq
+  julia 
 ```
-
-You will also have to install [`yq`](https://github.com/mikefarah/yq) which can be done via pip, apt, snap and even go. For more details please refer to its official documentation.
 
 ### Install recent CMake
 

--- a/fixtures/genesis-raw/include.jl
+++ b/fixtures/genesis-raw/include.jl
@@ -2,7 +2,7 @@ using .HostFixture
 using Test
 
 
-tester = HostFixture.Tester("Genesis", "tester")
+tester = HostFixture.Tester("Raw Genesis", true, "tester")
 
 HostFixture.execute(tester, 10) do (root, result)
     # Extract all hashes returned from log

--- a/runtimes/tester/.gitignore
+++ b/runtimes/tester/.gitignore
@@ -1,4 +1,5 @@
 /runtime/Cargo.lock
 /target/
+genesis.hash
 genesis.json
-genesis.yaml
+genesis.raw.json

--- a/runtimes/tester/Makefile
+++ b/runtimes/tester/Makefile
@@ -1,18 +1,21 @@
 .PHONY: all build version clean
 
-all: genesis.json genesis.yaml
+all: genesis.hash genesis.json genesis.raw.json
 
 build:
 	cargo build --release
 
-genesis.json: build
-	cargo run --release > $@
+genesis.hash: build
+	cargo run --release hash > $@
 
-genesis.yaml: genesis.json
-	yq -y < $< '.genesis.raw.top | { keys: keys_unsorted | map(.[2:]), values: map(.[2:]) }' > $@
+genesis.json: build
+	cargo run --release json > $@
+
+genesis.raw.json: build
+	cargo run --release raw > $@
 
 version:
 	@cargo metadata --format-version 1 | jq '.packages[] | select(.name=="sp-core").id' | cut -d' ' -f2
 
 clean:
-	rm -rf target genesis.json genesis.yaml
+	rm -rf target genesis.hash genesis.json genesis.raw.json

--- a/runtimes/tester/gossamer.docker.raw.config.toml
+++ b/runtimes/tester/gossamer.docker.raw.config.toml
@@ -12,7 +12,7 @@ babe = ""
 grandpa = ""
 
 [init]
-genesis = "/config/genesis.json"
+genesis = "/config/genesis.raw.json"
 
 [core]
 roles = 4

--- a/runtimes/tester/gossamer.raw.config.toml
+++ b/runtimes/tester/gossamer.raw.config.toml
@@ -12,7 +12,7 @@ babe = ""
 grandpa = ""
 
 [init]
-genesis = "./runtimes/tester/genesis.json"
+genesis = "./runtimes/tester/genesis.raw.json"
 
 [core]
 roles = 4


### PR DESCRIPTION
This extends the `tester-runtime` with the capability to compute its own genesis storage root hash, dropping the `substrate-adapter`, `yq` (and `python`) as a dependency to run the integration part of the testsuite.

It is also the prerequisite to test which host can generate a valid raw genesis, which will be provided in a separate pull request.