### PR TITLE
kagome-host: enable state version v1 test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -192,7 +192,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fixture: [ genesis-legacy ]
+        fixture: [ genesis-default, genesis-legacy ]
     name: "[test-${{ matrix.fixture }}] kagome"
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This PR will enable the new tester-runtime with state space version 1 for kagome. 

Needs to be rebase on #171 before Kagome even has v1 support.