### PR TITLE
ci: enable genesis-default for gossamer

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -221,7 +221,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fixture: [ genesis-legacy ]
+        fixture: [ genesis-default, genesis-legacy ]
     name: "[test-${{ matrix.fixture }}] gossamer"
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This PR will enable the new tester-runtime with state space version 1 for gossamer.