### PR TITLE
Fix WAVM initialization in Kagome adapter

### DIFF
--- a/adapters/kagome/CMakeLists.txt
+++ b/adapters/kagome/CMakeLists.txt
@@ -59,8 +59,8 @@ message(STATUS "Download from binary cache: ${HUNTER_USE_CACHE_SERVERS}")
 # Setup hunter
 include(cmake/HunterGate.cmake)
 HunterGate(
-  URL "https://github.com/soramitsu/soramitsu-hunter/archive/v0.23.257-soramitsu23.tar.gz"
-  SHA1 "f42cec23fced76800b87191525ee1fa6f9c088a5"
+  URL "https://github.com/soramitsu/soramitsu-hunter/archive/v0.23.257-soramitsu24.tar.gz"
+  SHA1 "7476c4de9fdfb184e2ac29e5dd26ca3441e6fc61"
   FILEPATH "${CMAKE_SOURCE_DIR}/cmake/HunterConfig.cmake"
 )
 

--- a/adapters/kagome/src/host_api/helpers.cpp
+++ b/adapters/kagome/src/host_api/helpers.cpp
@@ -273,6 +273,7 @@ namespace helpers {
                      module_instance.error().message().data());
 
     module_instance_ = module_instance.value();
+    module_instance_->borrow([]() {});
 
     // Get memory provider
     memory_provider_ = module_instance_->getEnvironment().memory_provider;

--- a/adapters/kagome/src/host_api/helpers.hpp
+++ b/adapters/kagome/src/host_api/helpers.hpp
@@ -74,9 +74,7 @@ namespace helpers {
         encoded_args.put(std::move(res.value()));
       }
 
-      PtrSize args_span{memory.storeBuffer(encoded_args)};
-
-      auto result = module_instance_->callExportFunction(name, args_span);
+      auto result = module_instance_->callExportFunction(name, encoded_args);
       BOOST_ASSERT_MSG(result.has_value(), result.error().message().data());
 
       auto reset = module_instance_->resetEnvironment();


### PR DESCRIPTION
Changes in kagome runtime initialization, which resolve some threading issues, caused WAVM tests failing in polkadot-tests. Runtime instances should be now 'borrowed' before usage, to populate the thread-local stack used to expose host API implementation to runtime.